### PR TITLE
Add selectable slide formats for carousel generator

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -199,6 +199,64 @@ input[type="text"]:focus {
   font-size: 13px;
 }
 
+.format-selector {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-top: 10px;
+}
+
+.format-option {
+  padding: 16px;
+  border: 2px solid var(--color-border);
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.format-option:hover {
+  border-color: var(--color-primary);
+}
+
+.format-option.active {
+  border-color: var(--color-primary);
+  background: #e3f2fd;
+}
+
+.format-preview {
+  width: 60px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.format-preview.square {
+  height: 60px;
+}
+
+.format-preview.portrait {
+  height: 75px;
+}
+
+.format-icon {
+  font-size: 12px;
+  font-weight: 600;
+  color: #666;
+}
+
+.format-size {
+  font-size: 11px;
+  color: var(--color-text-light);
+}
+
 .btn {
   width: 100%;
   padding: 16px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ function App() {
     setText,
     updateConfig,
     setTheme,
+    setFormat,
     generate,
     copySlide,
     downloadSlide,
@@ -109,6 +110,35 @@ function App() {
                     <div className="theme-name">{theme.name}</div>
                   </div>
                 ))}
+              </div>
+            </div>
+
+            <div className="form-group">
+              <label>Формат слайдов</label>
+              <div className="format-selector">
+                <button
+                  className={`format-option ${config.format === 'square' ? 'active' : ''}`}
+                  onClick={() => setFormat('square')}
+                  type="button"
+                >
+                  <div className="format-preview square">
+                    <div className="format-icon">1:1</div>
+                  </div>
+                  <span>Квадрат</span>
+                  <span className="format-size">1080×1080</span>
+                </button>
+
+                <button
+                  className={`format-option ${config.format === 'portrait' ? 'active' : ''}`}
+                  onClick={() => setFormat('portrait')}
+                  type="button"
+                >
+                  <div className="format-preview portrait">
+                    <div className="format-icon">4:5</div>
+                  </div>
+                  <span>Вертикальный</span>
+                  <span className="format-size">1080×1350</span>
+                </button>
               </div>
             </div>
 

--- a/src/modules/render.js
+++ b/src/modules/render.js
@@ -16,13 +16,18 @@ export class RenderEngine {
    * @returns {HTMLCanvasElement} Canvas с отрисованным слайдом
    */
   render(slide, theme, config) {
+    const formatKey = config.format || theme.canvas.defaultFormat || 'square';
+    const canvasSize =
+      theme.canvas.formats[formatKey] ||
+      theme.canvas.formats[theme.canvas.defaultFormat] ||
+      theme.canvas.formats.square;
     const canvas = document.createElement('canvas');
-    canvas.width = theme.canvas.width;
-    canvas.height = theme.canvas.height;
+    canvas.width = canvasSize.width;
+    canvas.height = canvasSize.height;
     const ctx = canvas.getContext('2d');
 
     // 1. Background
-    this.drawBackground(ctx, theme.canvas);
+    this.drawBackground(ctx, theme.canvas, canvasSize);
 
     // 2. Calculate layout
     const layout = this.layoutEngine.calculateLayout(slide, theme, config);
@@ -57,9 +62,11 @@ export class RenderEngine {
     });
   }
 
-  drawBackground(ctx, config) {
+  drawBackground(ctx, config, canvasSize) {
     ctx.fillStyle = config.background;
-    ctx.fillRect(0, 0, config.width, config.height);
+    const width = canvasSize?.width ?? ctx.canvas.width;
+    const height = canvasSize?.height ?? ctx.canvas.height;
+    ctx.fillRect(0, 0, width, height);
   }
 
   drawHeader(ctx, header, theme, config) {
@@ -175,14 +182,22 @@ export class LayoutEngine {
    * Рассчитывает макет слайда
    */
   calculateLayout(slide, theme, config) {
+    const formatKey = config.format || theme.canvas.defaultFormat || 'square';
+    const canvasSize =
+      theme.canvas.formats[formatKey] ||
+      theme.canvas.formats[theme.canvas.defaultFormat] ||
+      theme.canvas.formats.square;
+    const canvasWidth = canvasSize?.width ?? theme.canvas.width;
+    const canvasHeight = canvasSize?.height ?? theme.canvas.height;
+
     const layout = {
       header: {
         username: { x: theme.spacing.padding, y: 138 },
-        slideNumber: { x: 1080 - theme.spacing.padding, y: 138 }
+        slideNumber: { x: canvasWidth - theme.spacing.padding, y: 138 }
       },
       footer: {
-        text: { x: theme.spacing.padding, y: 1020 },
-        arrow: { x: 1080 - theme.spacing.padding, y: 1025 }
+        text: { x: theme.spacing.padding, y: canvasHeight - 60 },
+        arrow: { x: canvasWidth - theme.spacing.padding, y: canvasHeight - 55 }
       }
     };
 
@@ -203,8 +218,8 @@ export class LayoutEngine {
     layout.textBox = {
       x: theme.spacing.padding,
       y: currentY,
-      width: 1080 - (theme.spacing.padding * 2),
-      maxHeight: 1080 - currentY - 150
+      width: canvasWidth - (theme.spacing.padding * 2),
+      maxHeight: canvasHeight - currentY - 150
     };
 
     return layout;

--- a/src/modules/themes.js
+++ b/src/modules/themes.js
@@ -7,10 +7,21 @@ export const themes = {
   dengi_market: {
     id: 'dengi_market',
     name: 'Денги Маркет',
-    canvas: { 
-      width: 1080, 
-      height: 1080, 
-      background: '#FFFFFF' 
+    canvas: {
+      formats: {
+        square: { width: 1080, height: 1080 },
+        portrait: { width: 1080, height: 1350 }
+      },
+      defaultFormat: 'square',
+      background: '#FFFFFF',
+      get width() {
+        const format = this.formats[this.defaultFormat];
+        return format?.width ?? 1080;
+      },
+      get height() {
+        const format = this.formats[this.defaultFormat];
+        return format?.height ?? 1080;
+      }
     },
     fonts: {
       header: { 
@@ -52,10 +63,21 @@ export const themes = {
   minimal: {
     id: 'minimal',
     name: 'Минимализм',
-    canvas: { 
-      width: 1080, 
-      height: 1080, 
-      background: '#F5F5F5' 
+    canvas: {
+      formats: {
+        square: { width: 1080, height: 1080 },
+        portrait: { width: 1080, height: 1350 }
+      },
+      defaultFormat: 'square',
+      background: '#F5F5F5',
+      get width() {
+        const format = this.formats[this.defaultFormat];
+        return format?.width ?? 1080;
+      },
+      get height() {
+        const format = this.formats[this.defaultFormat];
+        return format?.height ?? 1080;
+      }
     },
     fonts: {
       header: { 
@@ -97,10 +119,21 @@ export const themes = {
   vibrant: {
     id: 'vibrant',
     name: 'Яркий',
-    canvas: { 
-      width: 1080, 
-      height: 1080, 
-      background: '#FFFFFF' 
+    canvas: {
+      formats: {
+        square: { width: 1080, height: 1080 },
+        portrait: { width: 1080, height: 1350 }
+      },
+      defaultFormat: 'square',
+      background: '#FFFFFF',
+      get width() {
+        const format = this.formats[this.defaultFormat];
+        return format?.width ?? 1080;
+      },
+      get height() {
+        const format = this.formats[this.defaultFormat];
+        return format?.height ?? 1080;
+      }
     },
     fonts: {
       header: { 
@@ -142,10 +175,21 @@ export const themes = {
   dark: {
     id: 'dark',
     name: 'Тёмный',
-    canvas: { 
-      width: 1080, 
-      height: 1080, 
-      background: '#1A202C' 
+    canvas: {
+      formats: {
+        square: { width: 1080, height: 1080 },
+        portrait: { width: 1080, height: 1350 }
+      },
+      defaultFormat: 'square',
+      background: '#1A202C',
+      get width() {
+        const format = this.formats[this.defaultFormat];
+        return format?.width ?? 1080;
+      },
+      get height() {
+        const format = this.formats[this.defaultFormat];
+        return format?.height ?? 1080;
+      }
     },
     fonts: {
       header: { 
@@ -187,10 +231,21 @@ export const themes = {
   gradient: {
     id: 'gradient',
     name: 'Градиент',
-    canvas: { 
-      width: 1080, 
-      height: 1080, 
-      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)' 
+    canvas: {
+      formats: {
+        square: { width: 1080, height: 1080 },
+        portrait: { width: 1080, height: 1350 }
+      },
+      defaultFormat: 'square',
+      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+      get width() {
+        const format = this.formats[this.defaultFormat];
+        return format?.width ?? 1080;
+      },
+      get height() {
+        const format = this.formats[this.defaultFormat];
+        return format?.height ?? 1080;
+      }
     },
     fonts: {
       header: { 
@@ -277,6 +332,16 @@ export class ThemeSystem {
         badge: theme.colors.badge
       }
     }));
+  }
+
+  getCanvasSize(theme, format = 'square') {
+    const selectedTheme = typeof theme === 'string' ? this.getTheme(theme) : theme;
+    const formatKey = format || selectedTheme.canvas.defaultFormat || 'square';
+    return (
+      selectedTheme.canvas.formats[formatKey] ||
+      selectedTheme.canvas.formats[selectedTheme.canvas.defaultFormat] ||
+      selectedTheme.canvas.formats.square
+    );
   }
 
   /**

--- a/src/store.js
+++ b/src/store.js
@@ -33,7 +33,8 @@ export const useCarouselStore = create(
       config: {
         username: '@dengi_market',
         footer: 'ваш любимый ломбард',
-        theme: 'dengi_market'
+        theme: 'dengi_market',
+        format: 'square'
       },
       
       // UI состояние
@@ -79,6 +80,15 @@ export const useCarouselStore = create(
         themeSystem.setTheme(themeId);
         set((state) => ({
           config: { ...state.config, theme: themeId }
+        }));
+      },
+
+      /**
+       * Установить формат
+       */
+      setFormat: (format) => {
+        set((state) => ({
+          config: { ...state.config, format: format || 'square' }
         }));
       },
 


### PR DESCRIPTION
## Summary
- add format definitions for each theme with backwards compatible getters and helpers
- store the chosen slide format in state and expose a selector in the UI with styles
- update rendering and layout logic to respect the selected canvas dimensions

## Testing
- npm install *(fails: registry access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e651b26e348326962793bd3465b7dc