### PR TITLE
Show only slide count stat

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -335,7 +335,7 @@ input[type="text"]:focus {
 
 .stats {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 15px;
   margin-bottom: 20px;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -186,14 +186,6 @@ function App() {
                   <div className="stat-value">{stats.slideCount}</div>
                   <div className="stat-label">Слайдов</div>
                 </div>
-                <div className="stat-card">
-                  <div className="stat-value">{stats.charCount}</div>
-                  <div className="stat-label">Символов</div>
-                </div>
-                <div className="stat-card">
-                  <div className="stat-value">~{stats.timeEstimate}</div>
-                  <div className="stat-label">мин. на пост</div>
-                </div>
               </div>
             )}
 


### PR DESCRIPTION
## Summary
- update the preview stats widget to show only the slide count metric
- adjust the stats grid styling to center a single card cleanly

## Testing
- npm install *(fails: 403 Forbidden fetching @types/react)*

------
https://chatgpt.com/codex/tasks/task_e_68e65663f548832694356474f72c1950