### PR TITLE
Adjust slide limit warning after parsing

### DIFF
--- a/src/modules/export.js
+++ b/src/modules/export.js
@@ -181,6 +181,7 @@ export class Validator {
       'image/png',
       'image/webp'
     ];
+    this.slideLimitWarning = `Больше ${this.maxSlides} слайдов (Instagram ограничивает карусель ${this.maxSlides} слайдами)`;
   }
 
   /**
@@ -206,9 +207,7 @@ export class Validator {
     // Проверка на количество параграфов
     const paragraphs = text.split('\n\n').filter(p => p.trim());
     if (paragraphs.length > this.maxSlides) {
-      warnings.push(
-        `Больше ${this.maxSlides} слайдов (Instagram ограничивает карусель ${this.maxSlides} слайдами)`
-      );
+      warnings.push(this.slideLimitWarning);
     }
 
     // Проверка на подозрительные символы
@@ -363,6 +362,38 @@ export class Validator {
       .replace(/[<>]/g, '')           // Удаляем потенциально опасные символы
       .replace(/javascript:/gi, '')    // Удаляем JS инъекции
       .trim();
+  }
+
+  adjustSlideWarnings(validation, slideCount) {
+    if (!validation) {
+      return validation;
+    }
+
+    const shouldWarn = slideCount > this.maxSlides;
+    const warning = this.slideLimitWarning;
+
+    const updateWarnings = (warnings = []) => {
+      const filtered = warnings.filter(message => message !== warning);
+      if (shouldWarn) {
+        filtered.push(warning);
+      }
+      return filtered;
+    };
+
+    const updatedText = validation.text
+      ? {
+          ...validation.text,
+          warnings: updateWarnings(validation.text.warnings)
+        }
+      : validation.text;
+
+    const updatedWarnings = updateWarnings(validation.warnings);
+
+    return {
+      ...validation,
+      warnings: updatedWarnings,
+      text: updatedText
+    };
   }
 }
 

--- a/src/store.js
+++ b/src/store.js
@@ -97,11 +97,11 @@ export const useCarouselStore = create(
        */
       generate: async () => {
         const { text, config } = get();
-        
+
         // Валидация
-        const validation = validator.validateAll(text, [], config);
+        let validation = validator.validateAll(text, [], config);
         set({ validation });
-        
+
         if (!validation.isValid) {
           return;
         }
@@ -112,6 +112,9 @@ export const useCarouselStore = create(
           // Парсинг текста
           const slides = parser.parse(text);
           set({ slides });
+
+          validation = validator.adjustSlideWarnings(validation, slides.length);
+          set({ validation });
 
           // Получение темы
           const theme = themeSystem.getTheme(config.theme);


### PR DESCRIPTION
## Summary
- introduce a reusable slide limit warning string and helper in the validator to sync warnings with slide totals
- refresh the stored validation state after parsing so the slide warning reflects the generated slide count

## Testing
- npm test -- --run *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e65666038c8326a04ae9e1acecad77